### PR TITLE
Expose Progress Object in SpeziHealthKit

### DIFF
--- a/Sources/SpeziHealthKit/BulkUpload/BulkUploadSampleDataSource.swift
+++ b/Sources/SpeziHealthKit/BulkUpload/BulkUploadSampleDataSource.swift
@@ -39,7 +39,7 @@ final class BulkUploadSampleDataSource: HealthKitDataSource {
         }
     }
     
-    var progress: Progress {
+    public var progress: Progress {
         let progress = Progress(totalUnitCount: Int64(totalSamples))
         progress.completedUnitCount = Int64(processedSamples)
         return progress

--- a/Sources/SpeziHealthKit/Foundation Extensions/UserDefaults+Keys.swift
+++ b/Sources/SpeziHealthKit/Foundation Extensions/UserDefaults+Keys.swift
@@ -15,6 +15,8 @@ extension UserDefaults {
         static let healthKitAnchorPrefix = "Spezi.HealthKit.Anchors."
         static let healthKitDefaultPredicateDatePrefix = "Spezi.HealthKit.DefaultPredicateDate."
         static let bulkUploadAnchorPrefix = "Spezi.BulkUpload.Anchors."
+        static let bulkUploadTotalSamplesPrefix = "Spezi.BulkUpload.Total."
+        static let bulkUploadProcessedSamplesPrefix = "Spezi.BulkUpload.Processed."
         static let bulkUploadDefaultPredicateDatePrefix = "Spezi.BulkUpload.DefaultPredicateDate."
     }
 }

--- a/Sources/SpeziHealthKit/HealthKit.swift
+++ b/Sources/SpeziHealthKit/HealthKit.swift
@@ -74,6 +74,21 @@ public final class HealthKit: Module, EnvironmentAccessible, DefaultInitializabl
     private var healthKitDataSourceDescriptions: [HealthKitDataSourceDescription] = []
     @ObservationIgnored private var healthKitComponents: [any HealthKitDataSource] = []
     
+    public var progress: Progress {
+        var totalUnitCount: Int64 = 0
+        var completedUnitCount: Int64 = 0
+        for dataSource in healthKitComponents {
+            if let bulkDataSource = dataSource as? BulkUploadSampleDataSource {
+                let individualProgress = bulkDataSource.progress
+                totalUnitCount += individualProgress.totalUnitCount
+                completedUnitCount += individualProgress.completedUnitCount
+            }
+        }
+        let macroProgress = Progress(totalUnitCount: totalUnitCount)
+        macroProgress.completedUnitCount = completedUnitCount
+        return macroProgress
+    }
+    
     
     private var healthKitSampleTypes: Set<HKSampleType> {
         (initialHealthKitDataSourceDescriptions + healthKitDataSourceDescriptions).reduce(into: Set()) {


### PR DESCRIPTION
* Created a `Progress` object in `BulkUploadSampleDataSource`, which relies on `totalSamples` and `processedSamples` properties that get cached in user defaults
* Created an aggregate `Progress` object in `HealthKit` that aggregates across all `BulkUploadSampleDataSource.progress` objects